### PR TITLE
Add gitignore to top root folder and fix double header in tutorial part 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.orig
+node_modules/
+.idea/

--- a/tutorial-part-four/gatsby-config.js
+++ b/tutorial-part-four/gatsby-config.js
@@ -7,12 +7,12 @@ module.exports = {
     title: "Pandas Eating Lots",
   },
   plugins: [
-    {
-      resolve: `gatsby-plugin-layout`,
-      options: {
-          component: require.resolve(`./src/components/layout.js`)
-      }
-    },
+    // {
+    //   resolve: `gatsby-plugin-layout`,
+    //   options: {
+    //       component: require.resolve(`./src/components/layout.js`)
+    //   }
+    // },
     {
       resolve: `gatsby-source-filesystem`,
       options: {


### PR DESCRIPTION
I only commented out the plugin definition in the config file. You're welcome to delete it entirely if you want.